### PR TITLE
fix: table title can have null relationships

### DIFF
--- a/src/BlockStruct.ts
+++ b/src/BlockStruct.ts
@@ -110,7 +110,9 @@ const TableTitleBlockSchema = BlockBaseSchema.extend({
   Relationships: object({
     Type: literal('CHILD'),
     Ids: string().array(),
-  }).array(),
+  })
+    .array()
+    .nullable(),
 });
 export type TableTitleBlock = zinfer<typeof TableTitleBlockSchema>;
 


### PR DESCRIPTION
Fix for an error seen parsing a private document:

Block looks like this (some properties omitted)

```
{
    "BlockType": "TABLE_TITLE",
    "Page": 2,
    "PageClassification": null,
    "Query": null,
    "Relationships": null,
    "RowIndex": null,
    "RowSpan": null,
    "SelectionStatus": null,
    "Text": null,
    "TextType": null
}
```

Typically, a `TABLE_TITLE` block's relationships are words, but this title does not contain any text.

This could technically be a breaking change, if anybody relies on `Relationships` not being null. But I don't think this will be the case anywhere: several other block types have nullable relationships.